### PR TITLE
Update bin averaging function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,3 +12,5 @@ RoxygenNote: 6.1.1
 Imports: 
     multitaper,
     zoo
+Suggests:
+    testthat

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+test:
+	- Rscript -e "devtools::test()"
+
+coverage:
+	- Rscript -e "covr::package_coverage()"

--- a/R/AvgToBin.R
+++ b/R/AvgToBin.R
@@ -1,37 +1,66 @@
-#' @title Average a vector into bins
-#'@description Averages y into bins according to the positon of a in the breaks
-#'  Either give N=number of breaks, or N+1 breaks Breaks are defined as
-#'  x>breaks[i], and x<=breaks[i+1] if fill=T, fill empty bins using linear
-#'  interpolation from the neighbours to the center of the bin could be
-#'  considerably speeded up by using cut ?cut
-#' @param x vector of x values
-#' @param y vector of y values, same length as x
-#' @param N Number of breaks (or NULL if breaks are supplied)
-#' @param breaks vector of breaks (optional, instead if N)
-#' @param bFill if TRUE  fill empty bins using linear interpolation from the neighbours to the center of the bin
-#' @return list(breaks,centers,avg,nobs)
-#' Returns the breaks, centers, the averaged values and nobs, the number of observations averages
+#' Bin averaging
+#'
+#' Average a vector into bins.
+#'
+#' This function averages the vector \code{y} into bins according to the positon
+#' of \code{x} within the breaks. You can either specify a desired number N of
+#' breaks which are used to calculate the actual breaks via \code{pretty(x, N)},
+#' or directly specify the N + 1 break positions. The averaging bins are defined
+#' via \code{x > breaks[i]} and \code{x <= breaks[i + 1]}. If \code{bFill =
+#' TRUE}, empty bins are filled using linear interpolation from the neighbours
+#' to the center of the bin.
+#'
+#' Probably the binning could be considerably speeded up by using \code{?cut}.
+#'
+#' @param x vector of values on which the data in \code{y} is tabulated;
+#'   e.g. depth or time points.
+#' @param y vector of observation values to be averaged into bins. Must have the
+#'   same length as \code{x}.
+#' @param N desired number of breaks (ignored if \code{breaks} are supplied
+#'   directly).
+#' @param breaks vector of break point positions to define the averagig bins; if
+#'   omitted, break point positions are calculated from the range of \code{x}
+#'   and the desired number of breaks given by \code{N}.
+#' @param bFill logical; if \code{TRUE}, fill empty bins using linear
+#'   interpolation from the neighbours to the center of the bin.
+#'
+#' @return a list with four elements:
+#' \describe{
+#' \item{\code{breaks}:}{numeric vector of the used break point positions.}
+#' \item{\code{centers}:}{numeric vector with the positions of the bin centers.}
+#' \item{\code{avg}:}{numeric vector with the bin-averaged values.}
+#' \item{\code{nobs}:}{numeric vector with the number of observations
+#'   contributing to each bin average.}
+#' }
+#'
 #' @author Thomas Laepple
 #' @export
-AvgToBin<-function(x,y,N=NULL,breaks=pretty(x,N),bFill=FALSE)
-{
-    NBIN <- length(breaks) - 1
-    centers <- (breaks[1:NBIN] + breaks[2:(NBIN + 1)])/2
-    avg<-rep(NA,length(breaks)-1)
-    nobs<-rep(NA,length(breaks)-1)
-    for (i in 1:(length(breaks)-1)) {
-        selection<-y[which((x>breaks[i])&(x<=breaks[i+1]))]
-        avg[i]<-mean(na.omit(selection))
-        nobs[i]<-sum(!is.na(selection))
-        }
+AvgToBin <- function(x, y, N = 2, breaks = pretty(x, N), bFill = FALSE) {
 
-
-  if ((sum(is.na(avg))>0)&(bFill))
-  {
-      yInt<-approx(x,y,centers)$y
-      missing<-is.na(avg)
-      avg[missing]<-yInt[missing]
+  if (length(x) != length(y)) {
+    stop("'x' and 'y' must have the same length.", call. = FALSE)
   }
-   return(list(breaks=breaks,centers=centers,avg=avg,nobs=nobs))
-}
 
+  nBins <- length(breaks) - 1
+
+  centers <- (breaks[1 : nBins] + breaks[2 : (nBins + 1)]) / 2
+  nObs <- avg <- rep(NA, nBins)
+
+  for (i in 1 : nBins) {
+
+    selection <- y[which((x > breaks[i]) & (x <= breaks[i + 1]))]
+
+    avg[i]  <- mean(na.omit(selection))
+    nObs[i] <- sum(!is.na(selection))
+
+  }
+
+  if ((sum(missing <- is.na(avg)) > 0) & (bFill)) {
+
+    avg[missing] <- (approx(x, y, centers)$y)[missing]
+
+  }
+
+  list(breaks = breaks, centers = centers, avg = avg, nobs = nObs)
+
+}

--- a/R/AvgToBin.R
+++ b/R/AvgToBin.R
@@ -5,10 +5,11 @@
 #' This function averages the vector \code{y} into bins according to the positon
 #' of \code{x} within the breaks. You can either specify a desired number N of
 #' breaks which are used to calculate the actual breaks via \code{pretty(x, N)},
-#' or directly specify the N + 1 break positions. The averaging bins are defined
-#' via \code{x > breaks[i]} and \code{x <= breaks[i + 1]}. If \code{bFill =
-#' TRUE}, empty bins are filled using linear interpolation from the neighbours
-#' to the center of the bin.
+#' or directly specify the N + 1 break positions. For \code{right = TRUE} (the
+#' default) the averaging bins are defined via \code{x > breaks[i]} and \code{x
+#' <= breaks[i + 1]}, else they are defined via \code{x >= breaks[i]} and
+#' \code{x < breaks[i + 1]}. If \code{bFill = TRUE}, empty bins are filled using
+#' linear interpolation from the neighbours to the center of the bin.
 #'
 #' Probably the binning could be considerably speeded up by using \code{?cut}.
 #'

--- a/R/AvgToBin.R
+++ b/R/AvgToBin.R
@@ -21,6 +21,9 @@
 #' @param breaks vector of break point positions to define the averagig bins; if
 #'   omitted, break point positions are calculated from the range of \code{x}
 #'   and the desired number of breaks given by \code{N}.
+#' @param right logical; indicate whether the bin intervals should be closed on
+#'   the right and open on the left (\code{TRUE}, the default), or vice versa
+#'   (\code{FALSE}).
 #' @param bFill logical; if \code{TRUE}, fill empty bins using linear
 #'   interpolation from the neighbours to the center of the bin.
 #'
@@ -35,7 +38,8 @@
 #'
 #' @author Thomas Laepple
 #' @export
-AvgToBin <- function(x, y, N = 2, breaks = pretty(x, N), bFill = FALSE) {
+AvgToBin <- function(x, y, N = 2, breaks = pretty(x, N),
+                     right = TRUE, bFill = FALSE) {
 
   if (length(x) != length(y)) {
     stop("'x' and 'y' must have the same length.", call. = FALSE)
@@ -48,7 +52,11 @@ AvgToBin <- function(x, y, N = 2, breaks = pretty(x, N), bFill = FALSE) {
 
   for (i in 1 : nBins) {
 
-    selection <- y[which((x > breaks[i]) & (x <= breaks[i + 1]))]
+    if (right) {
+      selection <- y[which((x > breaks[i]) & (x <= breaks[i + 1]))]
+    } else {
+      selection <- y[which((x >= breaks[i]) & (x < breaks[i + 1]))]
+    }
 
     avg[i]  <- mean(na.omit(selection))
     nObs[i] <- sum(!is.na(selection))

--- a/man/AvgToBin.Rd
+++ b/man/AvgToBin.Rd
@@ -2,31 +2,50 @@
 % Please edit documentation in R/AvgToBin.R
 \name{AvgToBin}
 \alias{AvgToBin}
-\title{Average a vector into bins}
+\title{Bin averaging}
 \usage{
-AvgToBin(x, y, N = NULL, breaks = pretty(x, N), bFill = FALSE)
+AvgToBin(x, y, N = 2, breaks = pretty(x, N), bFill = FALSE)
 }
 \arguments{
-\item{x}{vector of x values}
+\item{x}{vector of values on which the data in \code{y} is tabulated;
+e.g. depth or time points.}
 
-\item{y}{vector of y values, same length as x}
+\item{y}{vector of observation values to be averaged into bins. Must have the
+same length as \code{x}.}
 
-\item{N}{Number of breaks (or NULL if breaks are supplied)}
+\item{N}{desired number of breaks (ignored if \code{breaks} are supplied
+directly).}
 
-\item{breaks}{vector of breaks (optional, instead if N)}
+\item{breaks}{vector of break point positions to define the averagig bins; if
+omitted, break point positions are calculated from the range of \code{x}
+and the desired number of breaks given by \code{N}.}
 
-\item{bFill}{if TRUE  fill empty bins using linear interpolation from the neighbours to the center of the bin}
+\item{bFill}{logical; if \code{TRUE}, fill empty bins using linear
+interpolation from the neighbours to the center of the bin.}
 }
 \value{
-list(breaks,centers,avg,nobs)
-Returns the breaks, centers, the averaged values and nobs, the number of observations averages
+a list with four elements:
+\describe{
+\item{\code{breaks}:}{numeric vector of the used break point positions.}
+\item{\code{centers}:}{numeric vector with the positions of the bin centers.}
+\item{\code{avg}:}{numeric vector with the bin-averaged values.}
+\item{\code{nobs}:}{numeric vector with the number of observations
+  contributing to each bin average.}
+}
 }
 \description{
-Averages y into bins according to the positon of a in the breaks
- Either give N=number of breaks, or N+1 breaks Breaks are defined as
- x>breaks[i], and x<=breaks[i+1] if fill=T, fill empty bins using linear
- interpolation from the neighbours to the center of the bin could be
- considerably speeded up by using cut ?cut
+Average a vector into bins.
+}
+\details{
+This function averages the vector \code{y} into bins according to the positon
+of \code{x} within the breaks. You can either specify a desired number N of
+breaks which are used to calculate the actual breaks via \code{pretty(x, N)},
+or directly specify the N + 1 break positions. The averaging bins are defined
+via \code{x > breaks[i]} and \code{x <= breaks[i + 1]}. If \code{bFill =
+TRUE}, empty bins are filled using linear interpolation from the neighbours
+to the center of the bin.
+
+Probably the binning could be considerably speeded up by using \code{?cut}.
 }
 \author{
 Thomas Laepple

--- a/man/AvgToBin.Rd
+++ b/man/AvgToBin.Rd
@@ -44,10 +44,11 @@ Average a vector into bins.
 This function averages the vector \code{y} into bins according to the positon
 of \code{x} within the breaks. You can either specify a desired number N of
 breaks which are used to calculate the actual breaks via \code{pretty(x, N)},
-or directly specify the N + 1 break positions. The averaging bins are defined
-via \code{x > breaks[i]} and \code{x <= breaks[i + 1]}. If \code{bFill =
-TRUE}, empty bins are filled using linear interpolation from the neighbours
-to the center of the bin.
+or directly specify the N + 1 break positions. For \code{right = TRUE} (the
+default) the averaging bins are defined via \code{x > breaks[i]} and \code{x
+<= breaks[i + 1]}, else they are defined via \code{x >= breaks[i]} and
+\code{x < breaks[i + 1]}. If \code{bFill = TRUE}, empty bins are filled using
+linear interpolation from the neighbours to the center of the bin.
 
 Probably the binning could be considerably speeded up by using \code{?cut}.
 }

--- a/man/AvgToBin.Rd
+++ b/man/AvgToBin.Rd
@@ -4,7 +4,7 @@
 \alias{AvgToBin}
 \title{Bin averaging}
 \usage{
-AvgToBin(x, y, N = 2, breaks = pretty(x, N), bFill = FALSE)
+AvgToBin(x, y, N = 2, breaks = pretty(x, N), right = TRUE, bFill = FALSE)
 }
 \arguments{
 \item{x}{vector of values on which the data in \code{y} is tabulated;
@@ -19,6 +19,10 @@ directly).}
 \item{breaks}{vector of break point positions to define the averagig bins; if
 omitted, break point positions are calculated from the range of \code{x}
 and the desired number of breaks given by \code{N}.}
+
+\item{right}{logical; indicate whether the bin intervals should be closed on
+the right and open on the left (\code{TRUE}, the default), or vice versa
+(\code{FALSE}).}
 
 \item{bFill}{logical; if \code{TRUE}, fill empty bins using linear
 interpolation from the neighbours to the center of the bin.}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(PaleoSpec)
+
+test_check("PaleoSpec")

--- a/tests/testthat/test-AvgToBin.R
+++ b/tests/testthat/test-AvgToBin.R
@@ -38,5 +38,11 @@ test_that("bin averaging works.", {
 
   expect_equal(actual, expected)
 
+  actual <- AvgToBin(x, y)
+
+  expect_equal(actual, expected)
+
+  # expect error
+  expect_error(AvgToBin(1, y))
 
 })

--- a/tests/testthat/test-AvgToBin.R
+++ b/tests/testthat/test-AvgToBin.R
@@ -42,6 +42,18 @@ test_that("bin averaging works.", {
 
   expect_equal(actual, expected)
 
+  # close the bins on the left side
+  actual <- AvgToBin(x, y, right = FALSE)
+
+  expected <- list(
+    breaks = c(0, 5, 10),
+    centers = c(2.5, 7.5),
+    avg = c(2.5, 7),
+    nobs = c(4, 5)
+  )
+
+  expect_equal(actual, expected)
+
   # expect error
   expect_error(AvgToBin(1, y))
 

--- a/tests/testthat/test-AvgToBin.R
+++ b/tests/testthat/test-AvgToBin.R
@@ -1,0 +1,42 @@
+context("Bin Averaging")
+
+test_that("bin averaging works.", {
+
+  x <- 1 : 9
+  y <- x
+
+  breaks <- seq(0.5, 9.5, 3)
+
+  expected <- list(
+    breaks = breaks,
+    centers = c(2, 5, 8),
+    avg = c(2, 5, 8),
+    nobs = rep(3, 3)
+  )
+
+  actual <- AvgToBin(x, y, breaks = breaks)
+
+  expect_equal(actual, expected)
+
+  xx <- x
+  xx[4 : 6] <- NA
+
+  expected$nobs <- c(3, 0, 3)
+
+  actual <- AvgToBin(xx, y, breaks = breaks, bFill = TRUE)
+
+  expect_equal(actual, expected)
+
+  expected <- list(
+    breaks = c(0, 5, 10),
+    centers = c(2.5, 7.5),
+    avg = c(3, 7.5),
+    nobs = c(5, 4)
+  )
+
+  actual <- AvgToBin(x, y, N = 2)
+
+  expect_equal(actual, expected)
+
+
+})


### PR DESCRIPTION
This PR adds a small update to the bin-averaging function 'AvgToBin()', which includes

* cleaning up of the code base;
* setting up test infrastructure and testing the function;
* adding the option to close the averaging bins on the left side of the breaks (the default was, and still is, to have open left side and to close the bins on the right side);
* improving and updating the function documentation.

Note that the testing of the function has been introduced _prior to_ any changes to the code base, ensuring that the default behaviour of the function has not changed under the subsequent updates.