### PR TITLE
Handle NA values in input to filter function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: PaleoSpec
 Title: Spectral tools for the ECUS group
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(person("Thomas", "Laepple", email = "tlaepple@awi.de", role = c("aut", "cre")), person("Thomas", "Muench", email = "tmuench@awi.de", role = c("aut")))
 Description: Spectral tools for the ECUS group
 Depends:
-    R (>= 3.5.1)
+    R (>= 3.6.1)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.2.0
 Authors@R: c(person("Thomas", "Laepple", email = "tlaepple@awi.de", role = c("aut", "cre")), person("Thomas", "Muench", email = "tmuench@awi.de", role = c("aut")))
 Description: Spectral tools for the ECUS group
 Depends:
-    R (>= 3.6.1)
+    R (>= 3.5.1)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,28 @@
+# PaleoSpec 0.2.1
+
+* Filter function `ApplyFilter()` now handles NA values in the input time
+  series: 
+  - leading and trailing NA values are automatically stripped from the
+    input so that they do not migrate into the filtered result upon applying any
+    of the endpoint constraint methods, but they are added in again after
+    applying the filter, so that the output result has the same length as the
+    input;
+ - internal NA values are still ignored per default, but can be removed by
+   linear interpolation from the neighbouring values by toggling the respective
+   new function parameter.
+* Source code for the function was tidied, the function documentation updated,
+  and unit code testing was added.
+
+# PaleoSpec 0.2.0
+
+* New function `SimPLS()` to simulate powerlaw timeseries with a prescribed
+  alpha, i.e. alpha*f^(-beta).
+
+# PaleoSpec 0.1.0
+
+* Proper package version.
+  
+# PaleoSpec 0.0.0.9000
+
+* Rough migration from bundle of functions based on `paleolibrary` to
+  `PaleoSpec` package.

--- a/R/ApplyFilter.R
+++ b/R/ApplyFilter.R
@@ -1,47 +1,80 @@
-#' @title  Apply a filter to a timeseries
-#' @description Apply a filter to a timeseries the timestep provided by ts is
-#'   not used!!!! Thus for timeseries with a different spacing than 1, the
-#'   filter has to be adapted Using endpoint constrains as describen in  Mann et
-#'   al., GRL 2003 no constraint (loss at both ends) (method=0) minimum norm
-#'   constraint (method=1) minimum slope constraint (method=2) minimum roughness
-#'   constraint (method=3) circular filtering (method=4)
-#' @param data Input timeseries (ts object)
-#' @param filter vector of filter weights
-#' @param method constraint method choice 0-4
-#' @return filtered timeseries (ts object)
+#' Filter time series
+#'
+#' Apply a given filter to a time series using different endpoint constraints as
+#' described below.
+#'
+#' Note that when passing objects of class \code{ts}, the time step provided is
+#' not used; thus, for time series with a time step different from 1, the filter
+#' has to be adapted accordingly.
+#'
+#' The function applies endpoint constrains following Mann et al., GRL, 2003;
+#' available methods are:
+#' \itemize{
+#'   \item method = 0: no constraint (loss at both ends);
+#'   \item method = 1: minimum norm constraint;
+#'   \item method = 2: minimum slope constraint;
+#'   \item method = 3: minimum roughness constraint;
+#'   \item method = 4: circular filtering.
+#' }
+#'
+#' @param data numeric vector with the input timeseries (standard or ts object).
+#' @param filter numeric vector of filter weights.
+#' @param method single integer for choosing an endpoint constraint method;
+#'   available choices are integers 0-4, see details.
+#' @return filtered timeseries as a ts object.
 #' @author Thomas Laepple
+#' @examples
+#' # Simple running mean filter across three bins
+#' 
+#' x <- 1 : 10
+#' filter <- rep(1 / 3, 3)
+#'
+#' # no endpoint constraints lead to loss at both ends
+#' ApplyFilter(x, filter, method = 0)
+#'
+#' # circular filtering avoids end losses, so as the other methods
+#' ApplyFilter(x, filter, method = 4)
 #' @export
 ApplyFilter <- function(data, filter, method = 0) {
-  N <- floor(length(filter)/2)
-  if (method == 0) {
-    result <- stats::filter(c(data), filter, circular = FALSE)
-    return(ts(result, frequency = frequency(data)))
-  }
 
-  if (method == 4) {
-    result <- stats::filter(c(data), filter, circular = TRUE)
-    return(ts(result, frequency = frequency(data)))
-  }
+  if (!method %in% (0 : 4))
+    stop("Unknown method; only 0 : 4 available.")
 
-  {
-    if (method == 1) # Minimum Norm
-    {
+  circular = FALSE
+
+  if (method == 0 | method == 4) {
+
+    if (method == 4) {circular = TRUE}
+
+    result <- stats::filter(c(data), filter, circular = circular)
+
+  } else {
+
+    N <- floor(length(filter) / 2)
+
+    if (method == 1) {
+
       before <- rep(mean(data), N)
-      after <- rep(mean(data), N)
-    }
-    if (method == 2) {
-      before <- c(data)[N:1]
-      after <- c(data)[length(data):(length(data) - N + 1)]
-    }
-    if (method == 3) {
-      before <- c(data)[N:1]
-      after <- c(data)[length(data):(length(data) - N + 1)]
+      after  <- rep(mean(data), N)
 
-      before <- c(data)[1] - (before - mean(before))
+    } else if (method == 2 | method == 3) {
 
-      after <- c(data)[length(data)] - (after - mean(after))
+      before <- c(data)[N : 1]
+      after  <- c(data)[length(data) : (length(data) - N + 1)]
+
+      if (method == 3) {
+
+        before <- c(data)[1] - (before - mean(before))
+        after  <- c(data)[length(data)] - (after - mean(after))
+
+      }
     }
-    result <- stats::filter(c(before, data, after), filter, circular = F)[(N + 1):(N + length(data))]
-    return(ts(result, frequency = frequency(data)))
+
+    result <- stats::filter(c(before, data, after), filter, circular = circular)
+    result <- result[(N + 1) : (N + length(data))]
+
   }
+
+  return(ts(result, frequency = frequency(data)))
+
 }

--- a/R/ApplyFilter.R
+++ b/R/ApplyFilter.R
@@ -1,13 +1,18 @@
 #' Filter time series
 #'
-#' Apply a given filter to a time series using different endpoint constraints as
-#' described below.
+#' Apply a given filter to a time series using different endpoint constraints.
 #'
 #' Note that when passing objects of class \code{ts}, the time step provided is
 #' not used; thus, for time series with a time step different from 1, the filter
 #' has to be adapted accordingly.
 #'
-#' The function applies endpoint constrains following Mann et al., GRL, 2003;
+#' Leading and trailing NA values are automatically stripped from the input
+#' vector so that they do not spread into the filtered data when applying the
+#' endpoint constraints, but added in again after filtering so that the output
+#' vector has the same length as the input. This does not apply to any internal
+#' NA values, which instead are handled by \code{na.rm}.
+#'
+#' The function applies endpoint constrains following Mann et al., GRL, 2004;
 #' available methods are:
 #' \itemize{
 #'   \item method = 0: no constraint (loss at both ends);
@@ -21,8 +26,15 @@
 #' @param filter numeric vector of filter weights.
 #' @param method single integer for choosing an endpoint constraint method;
 #'   available choices are integers 0-4, see details.
-#' @return filtered timeseries as a ts object.
+#' @param na.rm logical; control the handling of internal NA values in
+#'   \code{data}. If set to \code{TRUE}, any internal NA values are removed by
+#'   linear interpolation from the neighbouring values; defaults to
+#'   \code{FALSE}.
+#' @return a ts object with the filtered timeseries.
 #' @author Thomas Laepple
+#' @source The endpoint constraint methods are based on the study:\cr
+#'   Michael E. Mann, On smoothing potentially non‐stationary climate time
+#'   series, Geophys. Res. Lett., 31, L07214, doi:10.1029/2004GL019569, 2004.
 #' @examples
 #' # Simple running mean filter across three bins
 #' 
@@ -34,11 +46,32 @@
 #'
 #' # circular filtering avoids end losses, so as the other methods
 #' ApplyFilter(x, filter, method = 4)
+#'
+#' # leading and trailing NA's are ignored but added in again afterwards
+#' x <- c(NA, 1 : 10, NA)
+#' ApplyFilter(x, filter, method = 4)
+#'
+#' # ... but not internal NA's
+#' x <- c(1 : 5, NA, 7 : 10)
+#' ApplyFilter(x, filter, method = 4)
+#'
+#' # if not explicitly removed by linear interpolation
+#' ApplyFilter(x, filter, method = 4, na.rm = TRUE)
+#'
 #' @export
-ApplyFilter <- function(data, filter, method = 0) {
+ApplyFilter <- function(data, filter, method = 0, na.rm = FALSE) {
 
   if (!method %in% (0 : 4))
     stop("Unknown method; only 0 : 4 available.")
+
+  result <- rep(NA, length(data))
+
+  # remove leading and trailing NA's
+  x <- c(zoo::na.trim(data))
+  n <- length(x)
+
+  # linearly interpolate internal NA's if requested
+  if (na.rm) {x <- stats::approx(1 : n, x, 1 : n)$y}
 
   circular = FALSE
 
@@ -46,7 +79,7 @@ ApplyFilter <- function(data, filter, method = 0) {
 
     if (method == 4) {circular = TRUE}
 
-    result <- stats::filter(c(data), filter, circular = circular)
+    xf <- stats::filter(x, filter, circular = circular)
 
   } else {
 
@@ -54,26 +87,29 @@ ApplyFilter <- function(data, filter, method = 0) {
 
     if (method == 1) {
 
-      before <- rep(mean(data), N)
-      after  <- rep(mean(data), N)
+      before <- rep(mean(x), N)
+      after  <- rep(mean(x), N)
 
     } else if (method == 2 | method == 3) {
 
-      before <- c(data)[N : 1]
-      after  <- c(data)[length(data) : (length(data) - N + 1)]
+      before <- x[N : 1]
+      after  <- x[n : (n - N + 1)]
 
       if (method == 3) {
 
-        before <- c(data)[1] - (before - mean(before))
-        after  <- c(data)[length(data)] - (after - mean(after))
+        before <- x[1] - (before - mean(before))
+        after  <- x[n] - (after - mean(after))
 
       }
     }
 
-    result <- stats::filter(c(before, data, after), filter, circular = circular)
-    result <- result[(N + 1) : (N + length(data))]
+    xf <- stats::filter(c(before, x, after), filter, circular = circular)
+    xf <- xf[(N + 1) : (N + n)]
 
   }
+
+  i <- match(x[1], data) : match(x[n], data)
+  result[i] <- xf
 
   return(ts(result, frequency = frequency(data)))
 

--- a/man/ApplyFilter.Rd
+++ b/man/ApplyFilter.Rd
@@ -2,27 +2,51 @@
 % Please edit documentation in R/ApplyFilter.R
 \name{ApplyFilter}
 \alias{ApplyFilter}
-\title{Apply a filter to a timeseries}
+\title{Filter time series}
 \usage{
 ApplyFilter(data, filter, method = 0)
 }
 \arguments{
-\item{data}{Input timeseries (ts object)}
+\item{data}{numeric vector with the input timeseries (standard or ts object).}
 
-\item{filter}{vector of filter weights}
+\item{filter}{numeric vector of filter weights.}
 
-\item{method}{constraint method choice 0-4}
+\item{method}{single integer for choosing an endpoint constraint method;
+available choices are integers 0-4, see details.}
 }
 \value{
-filtered timeseries (ts object)
+filtered timeseries as a ts object.
 }
 \description{
-Apply a filter to a timeseries the timestep provided by ts is
-  not used!!!! Thus for timeseries with a different spacing than 1, the
-  filter has to be adapted Using endpoint constrains as describen in  Mann et
-  al., GRL 2003 no constraint (loss at both ends) (method=0) minimum norm
-  constraint (method=1) minimum slope constraint (method=2) minimum roughness
-  constraint (method=3) circular filtering (method=4)
+Apply a given filter to a time series using different endpoint constraints as
+described below.
+}
+\details{
+Note that when passing objects of class \code{ts}, the time step provided is
+not used; thus, for time series with a time step different from 1, the filter
+has to be adapted accordingly.
+
+The function applies endpoint constrains following Mann et al., GRL, 2003;
+available methods are:
+\itemize{
+  \item method = 0: no constraint (loss at both ends);
+  \item method = 1: minimum norm constraint;
+  \item method = 2: minimum slope constraint;
+  \item method = 3: minimum roughness constraint;
+  \item method = 4: circular filtering.
+}
+}
+\examples{
+# Simple running mean filter across three bins
+
+x <- 1 : 10
+filter <- rep(1 / 3, 3)
+
+# no endpoint constraints lead to loss at both ends
+ApplyFilter(x, filter, method = 0)
+
+# circular filtering avoids end losses, so as the other methods
+ApplyFilter(x, filter, method = 4)
 }
 \author{
 Thomas Laepple

--- a/man/ApplyFilter.Rd
+++ b/man/ApplyFilter.Rd
@@ -3,8 +3,13 @@
 \name{ApplyFilter}
 \alias{ApplyFilter}
 \title{Filter time series}
+\source{
+The endpoint constraint methods are based on the study:\cr
+  Michael E. Mann, On smoothing potentially non‐stationary climate time
+  series, Geophys. Res. Lett., 31, L07214, doi:10.1029/2004GL019569, 2004.
+}
 \usage{
-ApplyFilter(data, filter, method = 0)
+ApplyFilter(data, filter, method = 0, na.rm = FALSE)
 }
 \arguments{
 \item{data}{numeric vector with the input timeseries (standard or ts object).}
@@ -13,20 +18,30 @@ ApplyFilter(data, filter, method = 0)
 
 \item{method}{single integer for choosing an endpoint constraint method;
 available choices are integers 0-4, see details.}
+
+\item{na.rm}{logical; control the handling of internal NA values in
+\code{data}. If set to \code{TRUE}, any internal NA values are removed by
+linear interpolation from the neighbouring values; defaults to
+\code{FALSE}.}
 }
 \value{
-filtered timeseries as a ts object.
+a ts object with the filtered timeseries.
 }
 \description{
-Apply a given filter to a time series using different endpoint constraints as
-described below.
+Apply a given filter to a time series using different endpoint constraints.
 }
 \details{
 Note that when passing objects of class \code{ts}, the time step provided is
 not used; thus, for time series with a time step different from 1, the filter
 has to be adapted accordingly.
 
-The function applies endpoint constrains following Mann et al., GRL, 2003;
+Leading and trailing NA values are automatically stripped from the input
+vector so that they do not spread into the filtered data when applying the
+endpoint constraints, but added in again after filtering so that the output
+vector has the same length as the input. This does not apply to any internal
+NA values, which instead are handled by \code{na.rm}.
+
+The function applies endpoint constrains following Mann et al., GRL, 2004;
 available methods are:
 \itemize{
   \item method = 0: no constraint (loss at both ends);
@@ -47,6 +62,18 @@ ApplyFilter(x, filter, method = 0)
 
 # circular filtering avoids end losses, so as the other methods
 ApplyFilter(x, filter, method = 4)
+
+# leading and trailing NA's are ignored but added in again afterwards
+x <- c(NA, 1 : 10, NA)
+ApplyFilter(x, filter, method = 4)
+
+# ... but not internal NA's
+x <- c(1 : 5, NA, 7 : 10)
+ApplyFilter(x, filter, method = 4)
+
+# if not explicitly removed by linear interpolation
+ApplyFilter(x, filter, method = 4, na.rm = TRUE)
+
 }
 \author{
 Thomas Laepple

--- a/tests/testthat/test-ApplyFilter.R
+++ b/tests/testthat/test-ApplyFilter.R
@@ -43,3 +43,42 @@ test_that("apply filter function works.", {
   expect_equal(actual, expected)
 
 })
+
+test_that("NA removal works.", {
+
+  # remove leading/trailing NA's
+  x <- c(NA, NA, 1 : 10, NA)
+  filter <- rep(1 / 3, 3)
+
+  expected <- ts(c(NA, NA, NA, 2 : 9, NA, NA))
+  actual <- ApplyFilter(x, filter, method = 0)
+
+  expect_equal(actual, expected)
+
+  expected <- ts(round(c(NA, NA, 13 / 3, 2 : 9, 20 / 3, NA), 2))
+  actual <- round(ApplyFilter(x, filter, method = 4), 2)
+
+  expect_equal(actual, expected)
+
+  # but not internal NA's
+  x <- c(1 : 5, NA, 7 : 10)
+
+  expected <- ts(c(NA, 2 : 4, NA, NA, NA, 8 : 9, NA))
+  actual <- ApplyFilter(x, filter, method = 0)
+
+  expect_equal(actual, expected)
+
+  # ... if the internal NA's are not explicitly interpolated
+  expected <- ts(c(NA, 2 : 9, NA))
+  actual <- ApplyFilter(x, filter, method = 0, na.rm = TRUE)
+
+  expect_equal(actual, expected)
+
+  # test combined case
+  x <- c(NA, 1 : 11, NA, 13 : 14, NA, NA, 17 : 20, rep(NA, 3))
+  expected <- ts(c(NA, NA, 2 : 19, NA, rep(NA, 3)))
+  actual <- ApplyFilter(x, filter, method = 0, na.rm = TRUE)
+
+  expect_equal(actual, expected)
+
+})

--- a/tests/testthat/test-ApplyFilter.R
+++ b/tests/testthat/test-ApplyFilter.R
@@ -1,0 +1,42 @@
+context("Time series filtering")
+
+test_that("apply filter function works.", {
+
+  # test ApplyFilter with a simple running mean filter across three bins
+
+  x <- 1 : 10
+  filter <- rep(1 / 3, 3)
+
+  # test various endpoint constraint methods
+
+  # method = 0
+  expected <- ts(c(NA, 2 : 9, NA))
+  actual <- ApplyFilter(x, filter, method = 0)
+
+  expect_equal(actual, expected)
+
+  # method = 1
+  expected <- ts(round(c(8.5 / 3, 2 : 9, 24.5 / 3), 2))
+  actual <- round(ApplyFilter(x, filter, method = 1), 2)
+
+  expect_equal(actual, expected)
+
+  # method = 2
+  expected <- ts(round(c(4 / 3, 2 : 9, 29 / 3), 2))
+  actual <- round(ApplyFilter(x, filter, method = 2), 2)
+
+  expect_equal(actual, expected)
+
+  # method = 3
+  expected <- ts(round(c(4 / 3, 2 : 9, 29 / 3), 2))
+  actual <- round(ApplyFilter(x, filter, method = 3), 2)
+
+  expect_equal(actual, expected)
+
+  # method = 4
+  expected <- ts(round(c(13 / 3, 2 : 9, 20 / 3), 2))
+  actual <- round(ApplyFilter(x, filter, method = 4), 2)
+
+  expect_equal(actual, expected)
+
+})

--- a/tests/testthat/test-ApplyFilter.R
+++ b/tests/testthat/test-ApplyFilter.R
@@ -7,6 +7,9 @@ test_that("apply filter function works.", {
   x <- 1 : 10
   filter <- rep(1 / 3, 3)
 
+  # test error check
+  expect_error(ApplyFilter(x, filter, method = 10))
+
   # test various endpoint constraint methods
 
   # method = 0


### PR DESCRIPTION
This PR adds an update to the filter function `ApplyFilter()`, which now handles NA values in the input time series:

* leading and trailing NA values are automatically stripped from the input so that they do not migrate into the filtered result upon applying any of the endpoint constraint methods, but they are added in again after applying the filter so that the output result has the same length as the input;
* internal NA values are still ignored per default, but can be removed by linear interpolation from the neighbouring values by toggling the respective new function parameter.

In addition, the source code for the function was tidied, the function documentation updated, and unit code testing was added.